### PR TITLE
removed md_globals from markdown extensions

### DIFF
--- a/markdown_fixtitle.py
+++ b/markdown_fixtitle.py
@@ -36,7 +36,7 @@ class FixTitleExtension(markdown.extensions.Extension):
 		for key, value in configs.items():
 			self.setConfig(key, value)
 
-	def extendMarkdown(self, md, md_globals):
+	def extendMarkdown(self, md):
 		fext = self.TreeProcessorClass(md)
 		fext.config = self.getConfigs()
 		# Headerid ext is set to '>prettify'. With this set to '_end',

--- a/markdown_fixtitle.py
+++ b/markdown_fixtitle.py
@@ -39,13 +39,17 @@ class FixTitleExtension(markdown.extensions.Extension):
 	def extendMarkdown(self, md):
 		fext = self.TreeProcessorClass(md)
 		fext.config = self.getConfigs()
-		# Headerid ext is set to '>prettify'. With this set to '_end',
-		# it should always come after headerid ext (and honor ids assinged
-		# by the header id extension) if both are used. Same goes for
-		# attr_list extension. This must come last because we don't want
-		# to redefine ids after toc is created. But we do want toc prettified.
-		md.treeprocessors.add("fixtitle", fext, "_end")
 
+		# Headerid ext is set to '>prettify'. With this set to the lowest
+		# priority, it should always come after headerid ext (and honor ids
+		# assigned by the header id extension) if both are used. Same goes for
+		# attr_list extension. This must come last because we don't want to
+		# redefine ids after toc is created. But we do want toc prettified.
+
+		# Get the last element registered to force a sort then sneak a look at
+		# its priority..
+		_ = md.treeprocessors[-1]
+		md.treeprocessors.register(fext, "fixtitle", md.treeprocessors._priority[-1].priority - 10)
 
 def makeExtension(configs={}):
 	return FixTitleExtension(configs=configs)

--- a/markdown_frontpage.py
+++ b/markdown_frontpage.py
@@ -39,13 +39,17 @@ class FrontpageExtension(markdown.extensions.Extension):
 	def extendMarkdown(self, md):
 		fext = self.TreeProcessorClass(md)
 		fext.config = self.getConfigs()
-		# Headerid ext is set to '>prettify'. With this set to '_end',
-		# it should always come after headerid ext (and honor ids assinged
-		# by the header id extension) if both are used. Same goes for
-		# attr_list extension. This must come last because we don't want
-		# to redefine ids after toc is created. But we do want toc prettified.
-		md.treeprocessors.add("frontpage", fext, "_end")
 
+		# Headerid ext is set to '>prettify'. With this set to the lowest
+		# priority, it should always come after headerid ext (and honor ids
+		# assigned by the header id extension) if both are used. Same goes for
+		# attr_list extension. This must come last because we don't want to
+		# redefine ids after toc is created. But we do want toc prettified.
+
+		# Get the last element registered to force a sort then sneak a look at
+		# its priority..
+		_ = md.treeprocessors[-1]
+		md.treeprocessors.register(fext, "frontpage", md.treeprocessors._priority[-1].priority - 10)
 
 def makeExtension(configs={}):
 	return FrontpageExtension(configs=configs)

--- a/markdown_frontpage.py
+++ b/markdown_frontpage.py
@@ -36,7 +36,7 @@ class FrontpageExtension(markdown.extensions.Extension):
 		for key, value in configs.items():
 			self.setConfig(key, value)
 
-	def extendMarkdown(self, md, md_globals):
+	def extendMarkdown(self, md):
 		fext = self.TreeProcessorClass(md)
 		fext.config = self.getConfigs()
 		# Headerid ext is set to '>prettify'. With this set to '_end',

--- a/markdown_homepage_break.py
+++ b/markdown_homepage_break.py
@@ -43,7 +43,7 @@ class HomeBreakExtension(markdown.extensions.Extension):
 		for key, value in configs.items():
 			self.setConfig(key, value)
 
-	def extendMarkdown(self, md, md_globals):
+	def extendMarkdown(self, md):
 		hpbext = self.TreeProcessorClass(md)
 		hpbext.config = self.getConfigs()
 		# Headerid ext is set to '>prettify'. With this set to '_end',

--- a/markdown_homepage_break.py
+++ b/markdown_homepage_break.py
@@ -46,13 +46,17 @@ class HomeBreakExtension(markdown.extensions.Extension):
 	def extendMarkdown(self, md):
 		hpbext = self.TreeProcessorClass(md)
 		hpbext.config = self.getConfigs()
-		# Headerid ext is set to '>prettify'. With this set to '_end',
-		# it should always come after headerid ext (and honor ids assinged
-		# by the header id extension) if both are used. Same goes for
-		# attr_list extension. This must come last because we don't want
-		# to redefine ids after toc is created. But we do want toc prettified.
-		md.treeprocessors.add("hpb", hpbext, "_end")
 
+		# Headerid ext is set to '>prettify'. With this set to the lowest
+		# priority, it should always come after headerid ext (and honor ids
+		# assigned by the header id extension) if both are used. Same goes for
+		# attr_list extension. This must come last because we don't want to
+		# redefine ids after toc is created. But we do want toc prettified.
+
+		# Get the last element registered to force a sort then sneak a look at
+		# its priority..
+		_ = md.treeprocessors[-1]
+		md.treeprocessors.register(hpbext, "hpb", md.treeprocessors._priority[-1].priority - 10)
 
 def makeExtension(configs={}):
 	return HomeBreakExtension(configs=configs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2
 sh
 colorlog
-markdown==3.3
+markdown
 pybtex


### PR DESCRIPTION
This is (I hope) the fix for the markdown argument deprecation in #1 . Looks like we didn't use it anyways, so they've been removed.

`./website.py` builds fine for me locally.